### PR TITLE
Fix type warning in the panel (on Kirby 3.8.3)

### DIFF
--- a/blueprints/tabs/page.php
+++ b/blueprints/tabs/page.php
@@ -43,7 +43,7 @@ return function (Kirby $kirby) {
 
     if (sizeof($sections) > 0) {
         $columns['meta_sidebar'] = [
-            'sticky' => 'true',
+            'sticky' => true,
             'width' => '1/3',
             'sections' => $sections,
         ];


### PR DESCRIPTION
I got this warning in the panel, found the issue :
```
[Vue warn]: Invalid prop: type check failed for prop "sticky". Expected Boolean, got String with value "true".
```