### PR TITLE
Support meta_title overrides from page model

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Sometimes, you want special behavior for certain templates. The easiest way to a
 | Key | Type | Description |
 |:----|:-----|:------------|
 | `meta_description` | `string` | Provide a default description that is used, when the user had not entered a dedicated description for this page. This could e.g. be a truncated version of the page's text content. |
+| `meta_title` | `string` | Provide a default override page title that is used, when the user has not entered a title override for this page. This could be used to provide an autogenrated title. |
+| `meta_title_full` | `string` | Provide a page title override that does not append the title separate and site title. This exact title is used for the page. If this is passed, no other field is checked by this plugin. But your page model can check the plugin's fields like `meta_title`. |
 | `og_title_prefix` | `string` | Will be put in front of the page's OpenGraph title, e.g. `'ℹ️ '` or `'[Recipe ]` |
 | `og_image File` | `Kirby\Cms\File` | A `File` object, that sets the default OpenGraph image for this page. You can even generate custom images programatically and Wrap them in a `File` object, e.g. for the docs of your product (getkirby.com does this for the reference pages).
 | `@graph` | `array` | Things to add to the JSON-LD metadata in the page's head. If you need to reference the organization or person behind the website, use `url('/#owner')`. If you need to reference the website itself, use `url('/#website')`. |

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -3,7 +3,7 @@
 namespace FabianMichael\Meta;
 
 use Kirby\Cms\App as Kirby;
-use Kirby\Cms\Field;
+use Kirby\Content\Field;
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
@@ -74,7 +74,8 @@ class PageMeta
         bool $siteFallback = false,
         bool $configFallback = false,
         mixed $fallback = null
-    ) {
+    ): Field {
+
         // From content file ...
         $field = $this->page->content($this->languageCode)->get($key);
 

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -74,7 +74,7 @@ class PageMeta
         bool $siteFallback = false,
         bool $configFallback = false,
         mixed $fallback = null
-    ): Field {
+    ) {
         // From content file ...
         $field = $this->page->content($this->languageCode)->get($key);
 

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -418,21 +418,18 @@ class PageMeta
 
     public function title(): Field
     {
-        // Search in page model ...
-        if ($title = $this->metadata('meta_title_full')) {
-            return new Field($this->page, 'title', $title);
-        }
         $title = [];
         $siteTitle = $this->page->site()->title();
 
-        if ($this->page->isHomePage() === true) {
-            $title[] = $this->page->content($this->languageCode)->get('meta_title')
-                ->or($siteTitle)->toString();
+        if ($metaTitleFull = $this->metadata('meta_title_full')) {
+            $title[] = $metaTitleFull;
+        } else if ($this->page->isHomePage() === true) {
+            $title[] = $this->get(key: 'meta_title',
+                fallback: $siteTitle)->toString();
         } else {
             // TODO: Support pagination
-            $title[] = $this->page->content($this->languageCode)->get('meta_title')
-                ->or($this->page->title())->toString();
-
+            $title[] = $this->get(key: 'meta_title',
+                fallback: $this->page->title())->toString();
             $title[] = SiteMeta::titleSeparator();
             $title[] = $siteTitle->toString();
         }

--- a/src/PageMeta.php
+++ b/src/PageMeta.php
@@ -418,6 +418,10 @@ class PageMeta
 
     public function title(): Field
     {
+        // Search in page model ...
+        if ($title = $this->metadata('meta_title_full')) {
+            return new Field($this->page, 'title', $title);
+        }
         $title = [];
         $siteTitle = $this->page->site()->title();
 


### PR DESCRIPTION
WIP: Does not support preview yet.

Ref #37.

My use case: in some types of pages, I don't want to append title separator and site title to the page title.

One alternative implementation is to provide a boolean in the pageModel->metadata() function that controls whether to append the site title to the page title.

Let me know if you want me to change the implementation.